### PR TITLE
Corrigendum tool_list.yaml

### DIFF
--- a/tool_list.yaml
+++ b/tool_list.yaml
@@ -132,7 +132,7 @@ tools:
   owner: ethevenot
   tool_panel_section_id: 'statistics_ALL'
   revisions:
-    - '526f8258e8a' # v2.3.10
+    - '5526f8258e8a' # v2.3.10
 - name: anova
   owner: lecorguille
   tool_panel_section_id: 'statistics_ALL'


### PR DESCRIPTION
A digit missing from the revision tag for `multivariate` causes `docker build` to fail.